### PR TITLE
fixed border cases for n<2 and tests (#20)

### DIFF
--- a/R/as_digraph6.R
+++ b/R/as_digraph6.R
@@ -22,8 +22,8 @@ as_digraph6.default <- function(object) {
 #' @export
 as_digraph6.matrix <- function(object) {
   n <- ncol(object)
-  if( n < 2)
-    stop("as_digraph6 handles networks of size greater 1")
+  # if( n < 2)
+  #   stop("as_digraph6 handles networks of size greater 1")
   if( n != nrow(object) )
     stop("'object' must be square matrix")
   v <- c(t(object))

--- a/R/as_sparse6.R
+++ b/R/as_sparse6.R
@@ -27,9 +27,9 @@ as_sparse6.matrix <- function(object, n, ...) {
   nr <- nrow(object)
   if( nc != 2)
     stop("as_sparse6 only handles edgelists with 2 columns")
-  if(nr==0){
-    stop("as_sparse6 only handles edgelists with more than 1 row")
-  }
+  # if(nr==0){
+  #   stop("as_sparse6 only handles edgelists with more than 1 row")
+  # }
   # bring edgelist in right order if needed
   if(!(all(object[,1]>object[,2]) & all(diff(object[,1])>=0))){
     object <- t(apply(object, 1, sort, decreasing = TRUE))
@@ -37,7 +37,13 @@ as_sparse6.matrix <- function(object, n, ...) {
   }
   
   # n <- max(object)
-  stopifnot(n >= max(object))
+  # catch boundary case of empty graph
+  if(nr!=0){
+    stopifnot(n >= max(object))  
+  } else{
+    stopifnot(n>=0)
+  }
+  
   k <- length(d2b(n - 1))
 
   object <- object - 1

--- a/R/from_digraph6.R
+++ b/R/from_digraph6.R
@@ -48,6 +48,9 @@ as_amatrix_digraph6 <- function(object) {
     rn <- r[2]
     rg <- r[ seq(3, length(r)) ]
     n <- as.numeric(rn) - 63
+    if(n<2){
+      return(matrix(0,n,n))
+    }
   }
   g <- sapply(as.numeric(rg)-63, function(x)
     expand_to_length( d2b(x), l=ceiling(length(x)/6)*6, what=0, where="start") )

--- a/R/from_graph6.R
+++ b/R/from_graph6.R
@@ -46,10 +46,13 @@ as_amatrix_graph6 <- function(object) {
   }    
   else{ #n<63
     rn <- r[1]
-    rg <- r[-1]
+    rg <- r[ seq(2, length(r)) ]
     n <- as.numeric(rn) - 63
+    if(n<2){
+      return(matrix(0,n,n))
+    }  
   }
-  if(length(rg) == 0) return(matrix(0, n, n))
+  
   g <- sapply(as.numeric(rg)-63, function(x)
     expand_to_length( d2b(x), l=ceiling(length(x)/6)*6, what=0, where="start") )
   g <- g[ seq(1, n*(n-1)/2) ]

--- a/R/from_sparse6.R
+++ b/R/from_sparse6.R
@@ -53,6 +53,9 @@ as_elist_sparse6 <- function(object){
     rn <- r[2]
     rg <- r[ seq(3, length(r)) ]
     n <- as.numeric(rn) - 63
+    if(n<2){
+      return(structure(matrix(0,0,2),gorder = n))
+    }
   }
   
   g <- c(sapply(as.numeric(rg)-63, function(x) expand_to_length( d2b(x), l=6, what=0, where="start")))

--- a/tests/testthat/test-as_dgraph6.R
+++ b/tests/testthat/test-as_dgraph6.R
@@ -1,6 +1,6 @@
 
 test_that("errors are given for improper input",{
-  expect_error( as_digraph6(matrix(1, 1, 1)), regexp="handles networks of size greater 1")
+  # expect_error( as_digraph6(matrix(1, 1, 1)), regexp="handles networks of size greater 1") function handles this now
   expect_error( as_digraph6(1), regexp="handle class")
 })
 

--- a/tests/testthat/test-as_sparse6.R
+++ b/tests/testthat/test-as_sparse6.R
@@ -2,7 +2,8 @@
 test_that("errors are given for improper input",{
   expect_error( as_sparse6(matrix(1, 1, 1)), regexp="handles edgelists with 2 columns")
   expect_error( as_sparse6(matrix(1, 3, 3)), regexp="handles edgelists with 2 columns")
-  expect_error( as_sparse6(matrix(1, 0, 2)), regexp="handles edgelists with more than 1 row")
+  # expect_error( as_sparse6(matrix(1, 0, 2)), regexp="handles edgelists with more than 1 row") function handles empty graphs now
+  expect_error( as_sparse6(matrix(1, 0, 2))) # added because as_sparse6.matrix needs n as input
   expect_error( as_sparse6(1), regexp="handle class")
 })
 

--- a/tests/testthat/test-i20-border-cases.R
+++ b/tests/testthat/test-i20-border-cases.R
@@ -83,7 +83,7 @@ test_that("graph of order 0 as sparse6", {
 test_that("sparse6 of order 0 as edgelist matrix", {
   string <- paste0(":", rawToChar(as.raw(fN(0))))
   expect_silent(
-    elist <- edgelist_from_sparse6(string)
+    elist <- edgelist_from_sparse6(string)[[1]]
   )
   expect_identical(
     elist, 
@@ -96,7 +96,7 @@ test_that("sparse6 of order 0 as igraph", {
   requireNamespace("igraph")
   string <- paste0(":", rawToChar(as.raw(fN(0))))
   expect_true(igraph::identical_graphs(
-    igraph_from_sparse6(string),
+    igraph_from_sparse6(string)[[1]],
     g0u
   ))
 })
@@ -105,7 +105,7 @@ test_that("sparse6 of order 0 as network", {
   requireNamespace("network")
   string <- paste0(":", rawToChar(as.raw(fN(0))))
   expect_identical(
-    network_from_sparse6(string),
+    network_from_sparse6(string)[[1]],
     network::network.initialize(n = 0, directed = FALSE)
   )
 })
@@ -126,8 +126,8 @@ test_that("sparse6 of order 1 as edgelist matrix", {
     elist <- edgelist_from_sparse6(string)
   )
   expect_identical(
-    elist, 
-    structure(matrix(0, 0, 2), gorder = 2)
+    elist[[1]], 
+    structure(matrix(0, 0, 2), gorder = 1)
   )
 })
 
@@ -135,7 +135,7 @@ test_that("sparse6 of order 1 as igraph", {
   requireNamespace("igraph")
   string <- paste0(":", rawToChar(as.raw(fN(1))))
   expect_true(igraph::identical_graphs(
-    igraph_from_sparse6(string),
+    igraph_from_sparse6(string)[[1]],
     g1u
   ))
 })
@@ -144,7 +144,7 @@ test_that("sparse6 of order 1 as network", {
   requireNamespace("network")
   string <- paste0(":", rawToChar(as.raw(fN(1))))
   expect_identical(
-    network_from_sparse6(string),
+    network_from_sparse6(string)[[1]],
     network::network.initialize(n = 1, directed = FALSE)
   )
 })
@@ -162,14 +162,14 @@ test_that("graph of order 0 as digraph6", {
   expect_identical(d6, string)
 })
 
-test_that("digraph6 of order 0 as edgelist matrix", {
+test_that("digraph6 of order 0 as adjacency matrix", {
   string <- paste0("&", rawToChar(as.raw(fN(0))))
   expect_silent(
-    elist <- adjacency_from_digraph6(string)
+    A <- adjacency_from_digraph6(string)[[1]]
   )
   expect_identical(
-    elist, 
-    structure(matrix(0, 0, 2), gorder = 0)
+    A, 
+    matrix(0, 0, 0)
   )
 })
 
@@ -178,7 +178,7 @@ test_that("digraph6 of order 0 as igraph", {
   requireNamespace("igraph")
   string <- paste0("&", rawToChar(as.raw(fN(0))))
   expect_true(igraph::identical_graphs(
-    igraph_from_digraph6(string),
+    igraph_from_digraph6(string)[[1]],
     g0d
   ))
 })
@@ -187,29 +187,30 @@ test_that("digraph6 of order 0 as network", {
   requireNamespace("network")
   string <- paste0("&", rawToChar(as.raw(fN(0))))
   expect_identical(
-    network_from_digraph6(string),
+    network_from_digraph6(string)[[1]],
     network::network.initialize(n = 0, directed = TRUE)
   )
 })
 
 
 
-test_that("graph of order 1 as sparse6", {
+test_that("graph of order 1 as digraph6", {
   expect_silent(
     d6 <- as_digraph6(g1d)
   )
-  string <- paste0("&", rawToChar(as.raw(fN(1))))
+  #string <- paste0("&", rawToChar(as.raw(fN(1)))) yields '&@' which is wrong according to nauty
+  string <- "&@?"
   expect_identical(d6, string)
 })
 
-test_that("digraph6 of order 1 as edgelist matrix", {
+test_that("digraph6 of order 1 as adjacency matrix", {
   string <- paste0("&", rawToChar(as.raw(fN(1))))
   expect_silent(
-    elist <- adjacency_from_digraph6(string)
+    A <- adjacency_from_digraph6(string)[[1]]
   )
   expect_identical(
-    elist, 
-    structure(matrix(0, 0, 2), gorder = 1)
+    A, 
+    matrix(0, 1, 1)
   )
 })
 
@@ -217,7 +218,7 @@ test_that("digraph6 of order 1 as igraph", {
   requireNamespace("igraph")
   string <- paste0("&", rawToChar(as.raw(fN(1))))
   expect_true(igraph::identical_graphs(
-    igraph_from_digraph6(string),
+    igraph_from_digraph6(string)[[1]],
     g1d
   ))
 })
@@ -226,7 +227,7 @@ test_that("digraph6 of order 1 as network", {
   requireNamespace("network")
   string <- paste0("&", rawToChar(as.raw(fN(1))))
   expect_identical(
-    network_from_digraph6(string),
+    network_from_digraph6(string)[[1]],
     network::network.initialize(n = 1, directed = TRUE)
   )
 })


### PR DESCRIPTION
This PR includes:

- all graph formats now handle empty graphs of any size properly.
- some tests needed to be adapted (see comment in #20) :
   - most outputs in `tests-i20-border-cases.R`  needed to access the first (and only) list element
   - some tests in `test-digraph6.R` and `test-sparse6.R` re no longer needed since boundary cases are covered

(all tests are passing now)