### PR TITLE
Graph size must be a scalar, not a vector

### DIFF
--- a/vignettes/rgraph6.Rmd
+++ b/vignettes/rgraph6.Rmd
@@ -149,7 +149,7 @@ set.seed(666)
 d <- data.frame(
   g6 = as_graph6(replicate(
     10,
-    igraph::random.graph.game(sample(3:12, replace=TRUE), p=.5, directed=FALSE),
+    igraph::sample_gnp(sample(3:12, 1), p=.5, directed=FALSE),
     simplify=FALSE
   ))
 )


### PR DESCRIPTION
Hi Michał,

This is another compatibility fix for igraph 2.0.  Graph sizes must be an actual scalar, not a vector.  Furthermore, `random.graph.game` is deprecated. `sample_gnp` and `sample_gnm` are the replacements.

CC @krlmlr